### PR TITLE
Manual permissions changes for americanrailswiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2032,6 +2032,16 @@ $wgConf->settings += [
 				'user' => true,
 			],
 		],
+
+		'americanrailswiki' => [
+			'suppress' => [ ],
+			'bureaucrat' => [
+				'userrights' => false,
+			],
+			'steward' => [
+				'userrights' => true,
+			],
+		],
 		'+metawiki' => [
 			'confirmed' => [
 				'mwoauthproposeconsumer' => true,


### PR DESCRIPTION
* Unset the 'suppress' group as I want to be able to call it the more traditional 'oversight' (still don't know why that was changed upstream) and the group isn't editable in ManageWiki

* Switch the 'userrights' permission from bureaucrat to steward. Apparently this can't be put in ManageWiki due to technical issues, but MediaWiki grants this right to crats by default and crats aren't the highest group on the wiki