### PR TITLE
Remove StopForumSpam as a global extension

### DIFF
--- a/GlobalExtensions.php
+++ b/GlobalExtensions.php
@@ -30,7 +30,6 @@ wfLoadExtensions( [
 	'RottenLinks',
 	'Scribunto',
 	'SpamBlacklist',
-	'StopForumSpam',
 	'TitleBlacklist',
 	'TorBlock',
 	'WebAuthn',

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1147,6 +1147,14 @@ $wgManageWikiExtensions = [
 		],
 		'section' => 'antispam',
 	],
+	'stopforumspam' => [
+		'name' => 'StopForumSpam',
+		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:StopForumSpam',
+		'var' => 'wmgUseStopForumSpam',
+		'conflicts' => false,
+		'requires' => [],
+		'section' => 'antispam',
+	],
 
 	// Special pages
 	'adminlinks' => [


### PR DESCRIPTION
This is causing some performance degradation as it checks user IPs on basically every single action